### PR TITLE
Add setsockopt() method.

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -4,6 +4,7 @@ module Celluloid
       # Create a new socket
       def initialize(type)
         @socket = Celluloid::ZMQ.context.socket ::ZMQ.const_get(type.to_s.upcase)
+        @options = { ::ZMQ::LINGER => 0 }
       end
 
       # Connect to the given 0MQ address
@@ -15,13 +16,19 @@ module Celluloid
         true
       end
 
+      def setsockopt(option, value)
+        @options[option] = value
+
+        unless ::ZMQ::Util.resultcode_ok? @socket.setsockopt(option, value)
+          @socket.close
+          raise IOError, "couldn't set ZMQ option #{option}: #{::ZMQ::Util.error_string}"
+        end
+      end
+
       # Bind to the given 0MQ address
       # Address should be in the form: tcp://1.2.3.4:5678/
       def bind(addr)
-        unless ::ZMQ::Util.resultcode_ok? @socket.setsockopt(::ZMQ::LINGER, 0)
-          @socket.close
-          raise IOError, "couldn't set ZMQ::LINGER: #{::ZMQ::Util.error_string}"
-        end
+        setsockopt(::ZMQ::LINGER, @options[::ZMQ::LINGER])
 
         unless ::ZMQ::Util.resultcode_ok? @socket.bind(addr)
           raise IOError, "couldn't bind to #{addr}: #{::ZMQ::Util.error_string}"


### PR DESCRIPTION
Still default LINGER to 0 using an options hash so if a user
sets it to something else, the bind() won't overwrite it.
