### PR TITLE
Relocate ZMQ::LINGER setting to ReadSocket

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -28,8 +28,6 @@ module Celluloid
       # Bind to the given 0MQ address
       # Address should be in the form: tcp://1.2.3.4:5678/
       def bind(addr)
-        setsockopt(::ZMQ::LINGER, @options[::ZMQ::LINGER])
-
         unless ::ZMQ::Util.resultcode_ok? @socket.bind(addr)
           raise IOError, "couldn't bind to #{addr}: #{::ZMQ::Util.error_string}"
         end
@@ -55,6 +53,17 @@ module Celluloid
 
     # Readable 0MQ sockets have a read method
     module ReadableSocket
+      # always set LINGER on readable sockets
+      def bind(addr)
+        setsockopt(::ZMQ::LINGER, @options[::ZMQ::LINGER])
+        super(addr)
+      end
+
+      def connect(addr)
+        setsockopt(::ZMQ::LINGER, @options[::ZMQ::LINGER])
+        super(addr)
+      end
+
       # Read a message from the socket
       def read(buffer = '')
         Celluloid.current_actor.wait_readable(@socket) if evented?


### PR DESCRIPTION
I could be wrong, but this looks more correct.
