### PR TITLE
include readable/writable in rep/req sockets

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -91,6 +91,7 @@ module Celluloid
     # ReqSockets are the counterpart of RepSockets (REQ/REP)
     class ReqSocket < Socket
       include ReadableSocket
+      include WritableSocket
 
       def initialize
         super :req
@@ -99,6 +100,7 @@ module Celluloid
 
     # RepSockets are the counterpart of ReqSockets (REQ/REP)
     class RepSocket < Socket
+      include ReadableSocket
       include WritableSocket
 
       def initialize


### PR DESCRIPTION
rep/req sockets are unusable without this.
