### PR TITLE
Use write instead of send

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -78,14 +78,15 @@ module Celluloid
     # Writable 0MQ sockets have a send method
     module WritableSocket
       # Send a message to the socket
-      def send(*messages)
+      def write(*messages)
         unless ::ZMQ::Util.resultcode_ok? @socket.send_strings messages.flatten
           raise IOError, "error sending 0MQ message: #{::ZMQ::Util.error_string}"
         end
 
         messages
       end
-      alias_method :<<, :send
+      alias_method :<<, :write
+      alias_method :send, :write # deprecated
     end
 
     # ReqSockets are the counterpart of RepSockets (REQ/REP)


### PR DESCRIPTION
The send method is native to Ruby. Why override it? Moreover, it goes hand is hand with "read": Read <-> Write and Send <-> Receive.
