### PR TITLE
ActorProxy is used for suspending IO tasks

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -38,15 +38,6 @@ module Celluloid
         @socket.close
       end
 
-      # Does the 0MQ socket support evented operation?
-      def evented?
-        actor = Thread.current[:celluloid_actor]
-        return unless actor
-
-        mailbox = actor.mailbox
-        mailbox.is_a?(Celluloid::IO::Mailbox) && mailbox.reactor.is_a?(Celluloid::ZMQ::Reactor)
-      end
-
       # Hide ffi-rzmq internals
       alias_method :inspect, :to_s
     end
@@ -68,7 +59,7 @@ module Celluloid
 
       # Read a message from the socket
       def read(buffer = '')
-        Celluloid.current_actor.wait_readable(@socket) if evented?
+        ZMQ.wait_readable(@socket) if ZMQ.evented?
 
         unless ::ZMQ::Util.resultcode_ok? @socket.recv_string buffer
           raise IOError, "error receiving ZMQ string: #{::ZMQ::Util.error_string}"


### PR DESCRIPTION
I just realized that celluloid-zmq probably has this same terrible
behavior as celluloid-io had. 

celluloid-io@015fa7dba66e90572645b51df7c22ccc50914020
celluloid-io@c28e5a2a185703401a6494af5b33514868989af0

[Here is one](https://github.com/celluloid/celluloid-zmq/blob/65d23d4779d3ea2b6673cbe547b8fd60e6161f04/lib/celluloid/zmq/sockets.rb#L71), I think.
