### PR TITLE
Depend on Celluloid::EventedMailbox instead of Celluloid::IO::Mailbox

### DIFF
--- a/celluloid-zmq.gemspec
+++ b/celluloid-zmq.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |gem|
   gem.version       = Celluloid::ZMQ::VERSION
 
   gem.add_dependency "celluloid",    ">= 0.13.0"
-  gem.add_dependency "celluloid-io", ">= 0.13.0"
   gem.add_dependency "ffi"
   gem.add_dependency "ffi-rzmq"
 

--- a/lib/celluloid/zmq.rb
+++ b/lib/celluloid/zmq.rb
@@ -1,6 +1,5 @@
 require 'ffi-rzmq'
 
-require 'celluloid/io'
 require 'celluloid/zmq/mailbox'
 require 'celluloid/zmq/reactor'
 require 'celluloid/zmq/sockets'

--- a/lib/celluloid/zmq/mailbox.rb
+++ b/lib/celluloid/zmq/mailbox.rb
@@ -3,9 +3,9 @@ require 'celluloid/io'
 module Celluloid
   module ZMQ
     # Replacement mailbox for Celluloid::ZMQ actors
-    class Mailbox < Celluloid::IO::Mailbox
+    class Mailbox < Celluloid::EventedMailbox
       def initialize
-        super Celluloid::ZMQ::Reactor.new
+        super(Reactor)
       end
     end
   end

--- a/spec/celluloid/zmq/mailbox_spec.rb
+++ b/spec/celluloid/zmq/mailbox_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require 'celluloid/rspec'
+
+describe Celluloid::ZMQ::Mailbox do
+  it_behaves_like "a Celluloid Mailbox"
+end


### PR DESCRIPTION
No dependency on `Celluloid::IO`. 
