### PR TITLE
Allow setting and getting socket options

### DIFF
--- a/lib/celluloid/zmq/sockets.rb
+++ b/lib/celluloid/zmq/sockets.rb
@@ -33,6 +33,22 @@ module Celluloid
         @socket.identity
       end
 
+      def set(option, value, length = nil)
+        unless ::ZMQ::Util.resultcode_ok? @socket.setsockopt(option, value, length)
+          raise IOError, "couldn't set value for option #{option}: #{::ZMQ::Util.error_string}"
+        end
+      end
+
+      def get(option)
+        option_value = []
+
+        unless ::ZMQ::Util.resultcode_ok? @socket.getsockopt(option, option_value)
+          raise IOError, "couldn't get value for option #{option}: #{::ZMQ::Util.error_string}"
+        end
+
+        option_value[0]
+      end
+
       # Bind to the given 0MQ address
       # Address should be in the form: tcp://1.2.3.4:5678/
       def bind(addr)

--- a/spec/celluloid/zmq/socket_spec.rb
+++ b/spec/celluloid/zmq/socket_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'celluloid/rspec'
+
+describe Celluloid::ZMQ::Socket, actor_system: :global do
+
+  it "allows setting and getting ZMQ options on the socket" do
+    socket = Celluloid::ZMQ::RepSocket.new
+    socket.set(::ZMQ::IDENTITY, "Identity")
+
+    identity = socket.get(::ZMQ::IDENTITY)
+
+    identity.should == "Identity"
+  end
+
+end


### PR DESCRIPTION
With the release of ZeroMQ 4, there are ever more options that can be set on a socket. Specifically in my case, the security options. This PR adds `#set` and `#get` to sockets which just proxy the arguments directly down to the ffi-rzmq handler for the socket. Celluloid doesn't have to care about types, that's handled deeper down.
