### PR TITLE
Fix specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,13 @@ require 'celluloid/zmq'
 
 logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'a')
 Celluloid.logger = Logger.new(logfile)
+
+Celluloid.shutdown_timeout = 1
+
+RSpec.configure do |config|
+  config.around do |ex|
+    Celluloid.boot
+    ex.run
+    Celluloid.shutdown
+  end
+end


### PR DESCRIPTION
My bad. Seems like I added a commit on celluloid/celluloid which calls `Celluloid.shutdown` in one of the shared actor specs. This works there since we start Celluloid before each spec with a similar `around` filter to this one.

Isolating the global state between examples seems like a good idea anyway, imo.
